### PR TITLE
Set gap size in i3's config file

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -289,4 +289,11 @@ void cmd_shmlog(I3_CMD, char *argument);
  */
 void cmd_debuglog(I3_CMD, char *argument);
 
+/**
+ * Implementation of 'gap_size <width>'
+ *
+ */
+
+void cmd_gap_size(I3_CMD, char *width);
+
 #endif

--- a/include/config.h
+++ b/include/config.h
@@ -202,6 +202,9 @@ struct Config {
 
     /* The number of currently parsed barconfigs */
     int number_barconfigs;
+
+    /* useless gap size */
+    int gap_size;
 };
 
 /**

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -35,6 +35,7 @@ CFGFUN(criteria_pop_state);
 CFGFUN(font, const char *font);
 CFGFUN(exec, const char *exectype, const char *no_startup_id, const char *command);
 CFGFUN(for_window, const char *command);
+CFGFUN(gap_size, const long width);
 CFGFUN(floating_minimum_size, const long width, const long height);
 CFGFUN(floating_maximum_size, const long width, const long height);
 CFGFUN(default_orientation, const char *orientation);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -39,6 +39,7 @@ state INITIAL:
   'scratchpad' -> SCRATCHPAD
   'mode' -> MODE
   'bar' -> BAR
+  'gap_size' -> GAP_SIZE
 
 state CRITERIA:
   ctype = 'class' -> CRITERION
@@ -84,6 +85,11 @@ state BORDER:
     -> call cmd_border($border_style, "0")
   border_style = '1pixel'
     -> call cmd_border($border_style, "1")
+
+# gap_size <size>
+state GAP_SIZE:
+  width = word
+      -> call cmd_gap_size($width)
 
 state BORDER_WIDTH:
   end

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -22,6 +22,7 @@ state INITIAL:
   'bar'                                    -> BARBRACE
   'font'                                   -> FONT
   'mode'                                   -> MODENAME
+  'gap_size'                               -> GAP_SIZE
   'floating_minimum_size'                  -> FLOATING_MINIMUM_SIZE_WIDTH
   'floating_maximum_size'                  -> FLOATING_MAXIMUM_SIZE_WIDTH
   'floating_modifier'                      -> FLOATING_MODIFIER
@@ -51,6 +52,11 @@ state INITIAL:
 state IGNORE_LINE:
   line
       -> INITIAL
+
+# gap_size <size>
+state GAP_SIZE:
+  width = number
+      -> call cfg_gap_size(&width)
 
 # floating_minimum_size <width> x <height>
 state FLOATING_MINIMUM_SIZE_WIDTH:

--- a/src/commands.c
+++ b/src/commands.c
@@ -2054,3 +2054,14 @@ void cmd_debuglog(I3_CMD, char *argument) {
     // XXX: default reply for now, make this a better reply
     ysuccess(true);
 }
+
+/**
+ * Implementation of 'gap_size <width>'
+ *
+ */
+
+void cmd_gap_size(I3_CMD, char *width) {
+    int px = atoi(width);
+
+    config.gap_size = px;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -467,6 +467,9 @@ void load_configuration(xcb_connection_t *conn, const char *override_configpath,
     /* Set default_orientation to NO_ORIENTATION for auto orientation. */
     config.default_orientation = NO_ORIENTATION;
 
+    /* default useless gaps width */
+    config.gap_size = 0;
+
     /* Set default urgency reset delay to 500ms */
     if (config.workspace_urgency_timer == 0)
         config.workspace_urgency_timer = 0.5;

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -251,6 +251,10 @@ CFGFUN(for_window, const char *command) {
     TAILQ_INSERT_TAIL(&assignments, assignment, assignments);
 }
 
+CFGFUN(gap_size, const long width) {
+    config.gap_size = width;
+}
+
 CFGFUN(floating_minimum_size, const long width, const long height) {
     config.floating_minimum_width = width;
     config.floating_minimum_height = height;

--- a/src/render.c
+++ b/src/render.c
@@ -12,8 +12,6 @@
  */
 #include "all.h"
 
-#define GAP_SIZE 12
-
 /* change this to 'true' if you want to have additional borders around every
  * container (for debugging purposes) */
 static bool show_debug_borders = false;
@@ -151,7 +149,8 @@ void render_con(Con *con, bool render_fullscreen, bool already_inset) {
                          con->type != CT_FLOATING_CON &&
                          con->type != CT_WORKSPACE);
     if ((!already_inset && should_inset)) {
-        Rect inset = (Rect) {GAP_SIZE, GAP_SIZE, GAP_SIZE * -2, GAP_SIZE * -2};
+        Rect inset = (Rect) {config.gap_size, config.gap_size,
+            config.gap_size * -2, config.gap_size * -2};
         rect = rect_add(rect, inset);
         if (!render_fullscreen) {
             con->rect = rect_add(con->rect, inset);
@@ -159,7 +158,7 @@ void render_con(Con *con, bool render_fullscreen, bool already_inset) {
                 con->window_rect = rect_add(con->window_rect, inset);
             }
         }
-        inset.height = GAP_SIZE * -1;
+        inset.height = config.gap_size * -1;
         con->deco_rect = rect_add(con->deco_rect, inset);
     }
 


### PR DESCRIPTION
Make use of i3's config logic to set the gap size in the config file.

for example: `gap_size 12` in `~/.i3/config`
